### PR TITLE
fix resume preview by using fallback

### DIFF
--- a/src/stores/appData.ts
+++ b/src/stores/appData.ts
@@ -136,7 +136,7 @@ export const useAppDataStore = create<AppDataStore>()(
           const result: ResumeGenerationResult = await generateResumeFlow(params);
 
           const outputs: AppOutputs = {
-            resume: result.finalResume,
+            resume: result.finalResume ?? result.resume,
             coverLetter: result.coverLetter,
             highlights: result.recruiterHighlights,
             toolkit: result.interviewToolkit,


### PR DESCRIPTION
## Summary
- ensure resume preview populates by falling back to `result.resume` when `finalResume` is missing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 71 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a27dd4384483249ee4ec515c95e588