### PR TITLE
fix: place font import before Tailwind directives

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,13 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 /* The Best Darn Job Resume Builder Design System
 Navy (#001f3f) primary, Orange (#FF851B) accent
 Clean, professional with subtle playful elements
 */
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 @layer base {
   :root {


### PR DESCRIPTION
## Summary
- move Google Fonts import before Tailwind directives in `index.css` to satisfy CSS `@import` ordering

## Testing
- `npm run build`
- `npm run lint` *(fails: many @typescript-eslint/no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a29ff6f3e48324948dadeff9797941