### PR TITLE
Fix resume generation flow and autostart

### DIFF
--- a/src/components/flow/StepResume.tsx
+++ b/src/components/flow/StepResume.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
@@ -12,16 +11,16 @@ import { ExportBar } from "@/components/dashboard/ExportBar";
 import { useToast } from "@/hooks/use-toast";
 
 export const StepResume = () => {
-  const [isGenerating, setIsGenerating] = useState(false);
-  const { 
-    settings, 
-    inputs, 
-    outputs, 
-    updateSettings, 
-    updateInputs, 
-    runGeneration,
+  const {
+    settings,
+    inputs,
+    outputs,
+    updateSettings,
+    updateInputs,
+    generateResume,
     getWordCount,
-    isOverLimit 
+    isOverLimit,
+    status
   } = useAppDataStore();
   const { toast } = useToast();
 
@@ -35,9 +34,8 @@ export const StepResume = () => {
       return;
     }
 
-    setIsGenerating(true);
     try {
-      await runGeneration();
+      await generateResume();
       toast({
         title: "Resume Generated!",
         description: "Your targeted resume has been created.",
@@ -48,8 +46,6 @@ export const StepResume = () => {
         description: "Please check your inputs and try again.",
         variant: "destructive",
       });
-    } finally {
-      setIsGenerating(false);
     }
   };
 
@@ -151,11 +147,11 @@ export const StepResume = () => {
         {/* Generate Button */}
         <Button
           onClick={handleGenerate}
-          disabled={isGenerating || !inputs.resumeText.trim() || !inputs.jobText.trim()}
+          disabled={status.loading || !inputs.resumeText.trim() || !inputs.jobText.trim()}
           className="w-full bg-gradient-to-r from-primary to-accent text-white hover:scale-105 transition-transform"
           size="lg"
         >
-          {isGenerating ? "Generating..." : "Generate Resume"}
+          {status.loading ? "Generating..." : "Generate Resume"}
           <Sparkles className="ml-2 h-5 w-5" />
         </Button>
       </div>
@@ -175,6 +171,12 @@ export const StepResume = () => {
             </div>
           )}
         </div>
+        {outputs?.resume && isOverWordLimit && (
+          <p className="text-sm text-destructive">
+            Your résumé exceeds the 550-word limit. Please trim it before
+            continuing.
+          </p>
+        )}
 
         <Card className="bg-muted/30">
           <CardContent className="p-6">

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -62,7 +62,7 @@ const DashboardPage = () => {
     getSkillGaps
   } = useDashboardStore();
 
-  const { updateInputs } = useAppDataStore();
+  const { hydrateFromDashboard } = useAppDataStore();
 
   // UI State
   const [showJobDialog, setShowJobDialog] = useState(false);
@@ -204,11 +204,10 @@ const DashboardPage = () => {
   };
 
   const handleSendToBuilder = (job: Job) => {
-    // Update the app data store with the job information
-    updateInputs({
+    hydrateFromDashboard({
+      resumeText: (masterResume as any)?.content || '',
       jobText: job.description,
-      companySignal: job.company_signal,
-      companyName: job.company
+      companySignal: job.company_signal
     });
 
     toast({
@@ -216,7 +215,7 @@ const DashboardPage = () => {
       description: `${job.title} details loaded into resume builder.`,
     });
 
-    navigate('/builder');
+    navigate('/builder?step=resume&autostart=1');
   };
 
   const handleDeleteJob = (job: Job) => {


### PR DESCRIPTION
## Summary
- add dashboard hydration and async resume generator with state flags
- await resume generation in builder step and show word limit error
- autostart builder generation and gate navigation on generated resume

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in supabase functions)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a2a1a11c8324b84d2f047c182ab5