### PR TITLE
Add default builder query params failsafe

### DIFF
--- a/src/pages/BuilderFlowPage.tsx
+++ b/src/pages/BuilderFlowPage.tsx
@@ -17,6 +17,14 @@ import { StepInterview } from "@/components/flow/StepInterview";
 import { FlowFooter } from "@/components/flow/FlowFooter";
 import { ReviewBar } from "@/components/flow/ReviewBar";
 
+if (typeof window !== 'undefined') {
+  const p = new URLSearchParams(window.location.search);
+  if (!p.get('step')) p.set('step','resume');
+  if (!p.get('autostart')) p.set('autostart','1');
+  const target = `${window.location.pathname}?${p.toString()}`;
+  if (target !== window.location.href) window.history.replaceState({}, '', target);
+}
+
 type FlowStep = 'resume' | 'cover-letter' | 'highlights' | 'interview';
 
 const steps: FlowStep[] = ['resume', 'cover-letter', 'highlights', 'interview'];


### PR DESCRIPTION
## Summary
- ensure BuilderFlowPage sets default `step` and `autostart` query params

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any. Specify a different type)


------
https://chatgpt.com/codex/tasks/task_e_68a2b964f9c08324824efda333bda1a2