### PR TITLE
Fix resume builder autostart and preview flow

### DIFF
--- a/src/components/common/ResumePreview.tsx
+++ b/src/components/common/ResumePreview.tsx
@@ -1,57 +1,37 @@
+"use client";
 import { Skeleton } from "@/components/ui/skeleton";
-import { FileText } from "lucide-react";
+import { useAppData } from "@/stores/appData";
 
-interface ResumePreviewProps {
-  resume: string;
-  inputs: { resumeText: string; jobText: string };
-  loading: boolean;
-}
+const SkeletonLines = ({ lines }: { lines: number }) => (
+  <div className="space-y-2">
+    {Array.from({ length: lines }).map((_, i) => (
+      <Skeleton key={i} className="h-4 w-full" />
+    ))}
+  </div>
+);
 
-export const ResumePreview = ({ resume, inputs, loading }: ResumePreviewProps) => {
-  if (loading) {
-    return (
-      <div className="space-y-3 min-h-[400px]">
-        <Skeleton className="h-4 w-3/4" />
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-5/6" />
-        <Skeleton className="h-4 w-2/3" />
-      </div>
-    );
-  }
+export const ResumePreview = () => {
+  const { inputs, outputs, loading } = useAppData((s) => ({
+    inputs: s.inputs,
+    outputs: s.outputs || {},
+    loading: s.loading,
+  }));
 
-  if (resume?.trim()) {
+  if (loading) return <SkeletonLines lines={6} />;
+
+  const txt = outputs.resume?.trim() || '';
+  if (txt) {
     return (
       <div className="space-y-4">
         <div className="bg-background rounded-lg p-4 max-h-[400px] overflow-y-auto">
-          <pre className="whitespace-pre-wrap text-sm leading-relaxed font-sans">
-            {resume}
-          </pre>
+          <pre className="whitespace-pre-wrap text-sm leading-relaxed font-sans">{txt}</pre>
         </div>
       </div>
     );
   }
 
   if (inputs.resumeText && inputs.jobText) {
-    return (
-      <div className="min-h-[400px] flex items-center justify-center">
-        <div className="text-center space-y-4">
-          <FileText className="h-12 w-12 text-muted-foreground mx-auto" />
-          <p className="text-muted-foreground">
-            Ready to generate. Click Generate to see preview.
-          </p>
-        </div>
-      </div>
-    );
+    return <div className="text-sm text-slate-500">Resume ready to generate — click <b>Generate</b>.</div>;
   }
-
-  return (
-    <div className="min-h-[400px] flex items-center justify-center">
-      <div className="text-center space-y-4">
-        <FileText className="h-12 w-12 text-muted-foreground mx-auto" />
-        <p className="text-muted-foreground">
-          Add your resume & job description to begin.
-        </p>
-      </div>
-    </div>
-  );
+  return <div className="text-sm text-slate-500">Add your résumé & job to see a preview.</div>;
 };

--- a/src/components/flow/StepResume.tsx
+++ b/src/components/flow/StepResume.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
@@ -6,7 +7,7 @@ import { Switch } from "@/components/ui/switch";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { FileText, Sparkles, AlertCircle } from "lucide-react";
-import { useAppDataStore } from "@/stores/appData";
+import { useAppData } from "@/stores/appData";
 import { ExportBar } from "@/components/dashboard/ExportBar";
 import { useToast } from "@/hooks/use-toast";
 import { ResumePreview } from "@/components/common/ResumePreview";
@@ -19,13 +20,12 @@ export const StepResume = () => {
     updateSettings,
     updateInputs,
     generateResume,
-    getWordCount,
-    status
-  } = useAppDataStore();
+    loading
+  } = useAppData();
   const { toast } = useToast();
 
   const resume = outputs?.resume ?? "";
-  const words = resume.trim() ? getWordCount(resume) : 0;
+  const words = (resume.trim().match(/\S+/g) || []).length;
   const canContinue = words > 0 && words <= 550;
 
   const handleGenerate = async () => {
@@ -150,11 +150,11 @@ export const StepResume = () => {
           onClick={async () => {
             await handleGenerate();
           }}
-          disabled={status.loading || !inputs.resumeText.trim() || !inputs.jobText.trim()}
+          disabled={loading || !inputs.resumeText.trim() || !inputs.jobText.trim()}
           className="w-full bg-gradient-to-r from-primary to-accent text-white hover:scale-105 transition-transform"
           size="lg"
         >
-          {status.loading ? "Generating..." : "Generate Resume"}
+          {loading ? "Generating…" : "Generate Resume"}
           <Sparkles className="ml-2 h-5 w-5" />
         </Button>
       </div>
@@ -175,24 +175,14 @@ export const StepResume = () => {
           )}
         </div>
         {!canContinue && words > 550 && (
-          <p className="text-orange-600 text-sm mt-2">Over 550 words — trim to continue.</p>
+          <p className="text-sm mt-2" style={{color:'#FF851B'}}>Over 550 words — trim to continue.</p>
         )}
 
         <Card className="bg-muted/30">
           <CardContent className="p-6 space-y-4">
-            {resume.trim() ? (
-              <>
-                <ResumePreview resume={resume} inputs={inputs} loading={status.loading} />
-                {!status.loading && (
-                  <ExportBar content={resume} filename="targeted-resume" />
-                )}
-              </>
-            ) : inputs.resumeText && inputs.jobText ? (
-              <div className="text-sm text-muted-foreground">
-                Ready — click <b>Generate</b>.
-              </div>
-            ) : (
-              <div className="text-sm text-muted-foreground">Add your résumé & job first.</div>
+            <ResumePreview />
+            {!loading && resume.trim() && (
+              <ExportBar content={resume} filename="targeted-resume" />
             )}
           </CardContent>
         </Card>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -20,7 +21,7 @@ import {
   type Job, 
   type Resume 
 } from "@/stores/dashboardStore";
-import { useAppDataStore } from "@/stores/appData";
+import { useAppDataStore, useAppData } from "@/stores/appData";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { 
@@ -393,7 +394,22 @@ const DashboardPage = () => {
                     handleCompareJob(jobs[0]);
                   }
                 }}
-                onGenerateTargeted={() => navigate('/builder')}
+                onGenerateTargeted={() => {
+                  const selectedJD = jobs[0];
+                  useAppData.getState().hydrateFromDashboard({
+                    resumeText: (masterResume ?? '').toString(),
+                    jobText:
+                      selectedJD?.description ??
+                      selectedJD?.jobDescription ??
+                      selectedJD?.text ??
+                      '',
+                    companySignal:
+                      selectedJD?.company_signal ??
+                      (selectedJD as any)?.companySignal ??
+                      ''
+                  });
+                  navigate('/builder?step=resume&autostart=1');
+                }}
                 hasJobs={jobs.length > 0}
                 hasMasterResume={!!masterResume}
               />


### PR DESCRIPTION
## Summary
- ensure dashboard CTA hydrates inputs and navigates with `step=resume&autostart=1`
- harden builder autostart logic and use store loading state for navigation gating
- simplify resume step and preview to reflect generation status and word limits
- add robust resume extraction and HTML comment stripping in store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 74 problems)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a2c37f87d48324afa9c36ab016fb69