### PR TITLE
Preserve autostart query parameter across builder flow steps

### DIFF
--- a/src/pages/BuilderFlowPage.tsx
+++ b/src/pages/BuilderFlowPage.tsx
@@ -75,12 +75,18 @@ const BuilderFlowPage = () => {
         const firstIncompleteStep = getFirstIncompleteStep();
         setCurrentStep(firstIncompleteStep);
         // Clean up URL
-        setSearchParams({ step: firstIncompleteStep });
+        const params: Record<string, string> = { step: firstIncompleteStep };
+        const autostart = searchParams.get('autostart');
+        if (autostart) params.autostart = autostart;
+        setSearchParams(params);
       }).catch((error) => {
         console.error('Error loading toolkit:', error);
         // If loading fails, start from the beginning
         setCurrentStep('resume');
-        setSearchParams({ step: 'resume' });
+        const params: Record<string, string> = { step: 'resume' };
+        const autostart = searchParams.get('autostart');
+        if (autostart) params.autostart = autostart;
+        setSearchParams(params);
       });
     } else {
       // Normal step handling
@@ -99,7 +105,10 @@ const BuilderFlowPage = () => {
     // Update URL when step changes (but not during toolkit loading)
     const toolkitId = searchParams.get('toolkit');
     if (!toolkitId) {
-      setSearchParams({ step: currentStep });
+      const params: Record<string, string> = { step: currentStep };
+      const autostart = searchParams.get('autostart');
+      if (autostart) params.autostart = autostart;
+      setSearchParams(params);
     }
   }, [currentStep, setSearchParams, searchParams]);
 


### PR DESCRIPTION
## Summary
- Keep `autostart` search param when loading toolkits and navigating steps

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 74 problems - Unexpected any in supabase functions and require import in tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_68a2caa88a44832488b4e03da9da3efb