### PR TITLE
Preserve query params during builder navigation

### DIFF
--- a/src/components/flow/Stepper.tsx
+++ b/src/components/flow/Stepper.tsx
@@ -1,25 +1,45 @@
-import { Check, FileText, Mail, Star, MessageCircle } from "lucide-react";
+import {
+  Check,
+  FileText,
+  Mail,
+  Star,
+  MessageCircle,
+  type LucideIcon,
+} from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { preserveQuery } from "@/lib/route";
+
+export type FlowStep = "resume" | "cover-letter" | "highlights" | "interview";
 
 interface StepperProps {
-  currentStep: string;
-  steps: string[];
-  onStepClick: (step: string) => void;
+  currentStep: FlowStep;
+  steps: FlowStep[];
+  onStepClick: (step: FlowStep) => void;
 }
 
-const stepConfig = {
-  'resume': { label: 'Resume', icon: FileText },
-  'cover-letter': { label: 'Cover Letter', icon: Mail },
-  'highlights': { label: 'Highlights', icon: Star },
-  'interview': { label: 'Interview', icon: MessageCircle },
+const stepConfig: Record<FlowStep, { label: string; icon: LucideIcon }> = {
+  "resume": { label: "Resume", icon: FileText },
+  "cover-letter": { label: "Cover Letter", icon: Mail },
+  "highlights": { label: "Highlights", icon: Star },
+  "interview": { label: "Interview", icon: MessageCircle },
 };
 
 export const Stepper = ({ currentStep, steps, onStepClick }: StepperProps) => {
   const getCurrentStepIndex = () => steps.indexOf(currentStep);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const goToStep = (step: FlowStep) => {
+    const current = new URLSearchParams(location.search);
+    const merged = preserveQuery(current, { step });
+    navigate({ pathname: location.pathname, search: merged.toString() }, { replace: true });
+    onStepClick(step);
+  };
 
   return (
     <div className="flex items-center justify-between max-w-2xl mx-auto">
       {steps.map((step, index) => {
-        const config = stepConfig[step as keyof typeof stepConfig];
+        const config = stepConfig[step];
         const Icon = config.icon;
         const isCompleted = index < getCurrentStepIndex();
         const isCurrent = step === currentStep;
@@ -28,7 +48,7 @@ export const Stepper = ({ currentStep, steps, onStepClick }: StepperProps) => {
         return (
           <div key={step} className="flex items-center">
             <button
-              onClick={() => isAccessible && onStepClick(step)}
+              onClick={() => isAccessible && goToStep(step)}
               disabled={!isAccessible}
               className={`
                 flex flex-col items-center space-y-2 p-3 rounded-xl transition-all

--- a/src/lib/route.ts
+++ b/src/lib/route.ts
@@ -1,0 +1,26 @@
+export type QueryLike = Record<string, string | string[] | undefined>;
+
+export function preserveQuery(current: URLSearchParams, next: QueryLike): URLSearchParams {
+  const merged = new URLSearchParams(current);
+  for (const [k, v] of Object.entries(next)) {
+    if (v == null) continue;
+    if (Array.isArray(v)) {
+      merged.delete(k);
+      v.forEach(val => merged.append(k, String(val)));
+    } else {
+      merged.set(k, String(v));
+    }
+  }
+  return merged;
+}
+
+/**
+ * Ensure autostart stays set unless explicitly disabled.
+ * If the current URL has autostart, keep it; if not, default to "1".
+ */
+export function ensureAutostart(params: URLSearchParams, desired?: '0' | '1'): URLSearchParams {
+  const out = new URLSearchParams(params.toString());
+  const current = out.get('autostart');
+  out.set('autostart', desired ?? current ?? '1');
+  return out;
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -205,8 +205,10 @@ const DashboardPage = () => {
   };
 
   const handleSendToBuilder = (job: Job) => {
+    type MasterResumeWithContent = Resume & { content?: string };
+    const resumeContent = (masterResume as MasterResumeWithContent)?.content ?? '';
     hydrateFromDashboard({
-      resumeText: (masterResume as any)?.content ?? '',
+      resumeText: resumeContent,
       jobText: job.description ?? '',
       companySignal: job.company_signal ?? ''
     });
@@ -379,7 +381,7 @@ const DashboardPage = () => {
                 </div>
                 <ToolkitsList
                   toolkits={toolkits}
-                  onCreateNew={() => navigate('/builder')}
+                  onCreateNew={() => navigate('/builder?step=resume&autostart=1')}
                 />
               </section>
             </div>
@@ -395,7 +397,11 @@ const DashboardPage = () => {
                   }
                 }}
                 onGenerateTargeted={() => {
-                  const selectedJD = jobs[0];
+                  const selectedJD = jobs[0] as (Job & {
+                    jobDescription?: string;
+                    text?: string;
+                    companySignal?: string;
+                  }) | undefined;
                   useAppData.getState().hydrateFromDashboard({
                     resumeText: (masterResume ?? '').toString(),
                     jobText:
@@ -405,7 +411,7 @@ const DashboardPage = () => {
                       '',
                     companySignal:
                       selectedJD?.company_signal ??
-                      (selectedJD as any)?.companySignal ??
+                      selectedJD?.companySignal ??
                       ''
                   });
                   navigate('/builder?step=resume&autostart=1');


### PR DESCRIPTION
## Summary
- add `preserveQuery` and `ensureAutostart` helpers to merge URL parameters
- keep `autostart` and other params when normalizing BuilderFlow URLs
- merge query params on step navigation and dashboard CTA
- type step navigation with shared `FlowStep` union
- tighten Dashboard CTA typing to avoid `any`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type; A `require()` style import is forbidden)*
- `npx eslint src/components/flow/Stepper.tsx src/pages/BuilderFlowPage.tsx src/pages/DashboardPage.tsx src/lib/route.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a2cb5cb5388324bd8dc90bbc42ebdd