### PR TITLE
feat: add logger utility and apply to resume service

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,24 @@
+const isProduction = process.env.NODE_ENV === 'production';
+
+export const logger = {
+  debug: (...args: unknown[]) => {
+    if (!isProduction) {
+      console.debug(...args);
+    }
+  },
+  info: (...args: unknown[]) => {
+    if (!isProduction) {
+      console.info(...args);
+    }
+  },
+  warn: (...args: unknown[]) => {
+    if (!isProduction) {
+      console.warn(...args);
+    }
+  },
+  error: (...args: unknown[]) => {
+    console.error(...args);
+  }
+};
+
+export default logger;

--- a/src/lib/resumeService.ts
+++ b/src/lib/resumeService.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/integrations/supabase/client";
+import { logger } from "./logger";
 
 export interface ResumeGenerationParams {
   mode: 'concise' | 'detailed' | 'executive';
@@ -44,7 +45,7 @@ export interface ResumeGenerationResult {
  */
 export async function generateResumeFlow(params: ResumeGenerationParams): Promise<ResumeGenerationResult> {
   try {
-    console.log('Starting AI resume generation with 7-phase process...');
+    logger.debug('Starting AI resume generation with 7-phase process...');
     
     // Call the Supabase Edge Function for AI processing
     const { data, error } = await supabase.functions.invoke('generate-resume', {
@@ -52,7 +53,7 @@ export async function generateResumeFlow(params: ResumeGenerationParams): Promis
     });
 
     if (error) {
-      console.error('Resume generation error:', error);
+      logger.error('Resume generation error:', error);
       throw new Error(`Resume generation failed: ${error.message}`);
     }
 
@@ -60,11 +61,11 @@ export async function generateResumeFlow(params: ResumeGenerationParams): Promis
       throw new Error('No data returned from resume generation');
     }
 
-    console.log('✅ AI resume generation completed successfully');
+    logger.debug('✅ AI resume generation completed successfully');
     return data as ResumeGenerationResult;
 
   } catch (error) {
-    console.error('Error in generateResumeFlow:', error);
+    logger.error('Error in generateResumeFlow:', error);
     throw error;
   }
 }


### PR DESCRIPTION
## Summary
- add shared logger utility that hides debug output in production while keeping errors
- use logger in resumeService instead of direct console calls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run` *(fails: 2 failed | 16 passed)*
- `npm run lint` *(fails: 77 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a2b0904083249a2095a2b38f38ac