### PR TITLE
Improve quality check settings typing and keyword matching

### DIFF
--- a/src/__tests__/qualityCheck.test.ts
+++ b/src/__tests__/qualityCheck.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import { performGreatnessCheck, QualitySettings } from '../lib/qualityCheck';
+
+describe('keyword alignment', () => {
+  const settings: QualitySettings = {
+    mode: 'detailed',
+    voice: 'first-person',
+    format: 'plain_text',
+    includeTable: false,
+    proofread: true,
+  };
+
+  test('does not count partial keyword matches (Java vs JavaScript)', () => {
+    const result = performGreatnessCheck(
+      'Experienced with JavaScript frameworks',
+      'Java',
+      settings
+    );
+    expect(result.factors.keywordAlignment).toBe(0);
+  });
+
+  test('counts exact keyword even within phrases (React vs React Native)', () => {
+    const result = performGreatnessCheck(
+      'Skilled in React Native development',
+      'React',
+      settings
+    );
+    expect(result.factors.keywordAlignment).toBe(1);
+  });
+
+  test('does not treat React as React Native when job requires the latter', () => {
+    const result = performGreatnessCheck(
+      'Experienced with React',
+      'React Native',
+      settings
+    );
+    expect(result.factors.keywordAlignment).toBeCloseTo(2 / 3, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit `QualitySettings` interface and use it in `performGreatnessCheck` and `assessCompleteness`
- tighten keyword matching with word-boundary regex
- cover keyword edge cases like React vs React Native with unit tests

## Testing
- `npx vitest run src/__tests__/qualityCheck.test.ts`
- `npm run lint` *(fails: many existing `no-explicit-any` and related lint errors)*
- `npx vitest run` *(fails: missing `execCommand` in copyToClipboard test, button count 0 in accessibility test)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a421e09c8324a23bffb05961c3b2