### PR TITLE
feat: validate admin analytics response

### DIFF
--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -8,11 +8,11 @@ import { Section } from '@/components/admin/Section';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/hooks/use-toast';
-import { 
-  getAnalyticsSummary, 
-  getUsersList, 
+import {
+  getAnalyticsSummary,
+  getUsersList,
   getToolkitsList,
-  type AdminAnalytics,
+  type AdminAnalyticsResponse,
   type AdminUser,
   type AdminToolkit
 } from '@/services/admin';
@@ -29,7 +29,9 @@ import {
 } from 'lucide-react';
 
 export const AdminPage = () => {
-  const [analytics, setAnalytics] = useState<AdminAnalytics | null>(null);
+  const [analytics, setAnalytics] = useState<
+    AdminAnalyticsResponse | null
+  >(null);
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [toolkits, setToolkits] = useState<AdminToolkit[]>([]);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- add `AdminAnalyticsResponse` Zod schema and type
- enforce runtime validation for admin analytics RPC
- update admin dashboard to consume typed analytics

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, forbidden require imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ab92c6d88324aa4e479477426246