### PR TITLE
Fix live preview resume updates

### DIFF
--- a/src/dev/DevPreviewProbe.tsx
+++ b/src/dev/DevPreviewProbe.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useAppDataStore } from "@/stores/appData";
+import { selectGeneratedResume } from "@/stores/appData";
+
+export function DevPreviewProbe() {
+  const s = useAppDataStore();
+  const generated = selectGeneratedResume(s);
+  return (
+    <div className="mt-4 rounded-md border p-3 text-xs">
+      <div className="font-semibold">Dev Probe</div>
+      <div>loading: {String(s?.status?.loading)}</div>
+      <div>outputs keys: {JSON.stringify(Object.keys(s?.outputs || {}))}</div>
+      <div>preview length: {generated?.length || 0}</div>
+      <div className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap bg-muted/30 p-2">
+        {generated || "(empty)"}
+      </div>
+      <div className="mt-2 flex gap-2">
+        <button
+          className="px-2 py-1 border rounded"
+          onClick={() =>
+            useAppDataStore.setState((st:any) => ({
+              outputs: { ...st.outputs, resume: generated || "TEST PREVIEW — wiring OK" },
+            }))
+          }
+        >
+          Force Preview
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- normalize store outputs and export `selectGeneratedResume`
- make `runGeneration` return text and always set `outputs.resume`
- update builder page preview to use selector with instant local preview
- add temporary `DevPreviewProbe` for debugging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6881ff9a48324ac62d58de6c7f8a3